### PR TITLE
Use expo status bar

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { SafeAreaView, View, Text, FlatList, StyleSheet, StatusBar } from 'react-native';
+import { SafeAreaView, View, Text, FlatList, StyleSheet } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
 import { useFonts, PlayfairDisplay_700Bold } from '@expo-google-fonts/playfair-display';
 import AppLoading from 'expo-app-loading';
 

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@expo-google-fonts/playfair-display": "^0.4.1",
     "expo": "^53.0.11",
     "expo-app-loading": "^2.1.1",
     "expo-font": "^13.3.1",
+    "expo-status-bar": "^2.2.3",
     "react": "^19.1.0",
     "react-native": "^0.80.0"
   },


### PR DESCRIPTION
## Summary
- import StatusBar from expo-status-bar
- install expo-status-bar and expo-google-fonts/playfair-display dependencies

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f2c9fce2883298dd2664c63ab2242