### PR TITLE
Add flashcard behavior to App

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Instructions for contributors
+
+- Use 2-space indentation for JavaScript and TypeScript files.
+- React components should be written in TypeScript (`.tsx`).
+- Run `npm test` before committing to ensure the Jest suite passes.
+- When adding dependencies, commit both `package.json` and `package-lock.json`.

--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { SafeAreaView, FlatList, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { SafeAreaView, StyleSheet, Pressable } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import { useFonts, PlayfairDisplay_700Bold } from '@expo-google-fonts/playfair-display';
 import AppLoading from 'expo-app-loading';
@@ -19,18 +19,29 @@ export default function App() {
     PlayfairDisplay_700Bold,
   });
 
+  const [index, setIndex] = useState(0);
+  const [reveal, setReveal] = useState(false);
+
   if (!fontsLoaded) {
     return <AppLoading />;
   }
 
+  const current = WORDS[index];
+
+  const handlePress = () => {
+    if (reveal) {
+      setIndex(Math.floor(Math.random() * WORDS.length));
+      setReveal(false);
+    } else {
+      setReveal(true);
+    }
+  };
+
   return (
     <SafeAreaView style={styles.container}>
-      <FlatList
-        data={WORDS}
-        renderItem={({ item }) => <WordCard word={item.word} definition={item.definition} />}
-        keyExtractor={(item) => item.id}
-        contentContainerStyle={styles.list}
-      />
+      <Pressable style={styles.flex} onPress={handlePress}>
+        <WordCard word={current.word} definition={current.definition} reveal={reveal} />
+      </Pressable>
       <StatusBar style="auto" />
     </SafeAreaView>
   );
@@ -41,7 +52,9 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#fafafa',
   },
-  list: {
+  flex: {
+    flex: 1,
+    justifyContent: 'center',
     padding: 16,
   },
 });

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Obscurdle
+
+Obscurdle is a simple React Native/Expo application that acts like a vocabulary flashcard game. One word is shown at a time. Tap the screen to reveal its definition and tap again for a new random word. The project is written in TypeScript and includes a small Jest test suite.
+
+## Development
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Start the Expo development server:
+
+```bash
+npx expo start
+```
+
+3. Run tests:
+
+```bash
+npm test
+```
+
+## Repository layout
+
+- `App.tsx` – the main entry point showing a single `WordCard` that responds to screen taps.
+- `WordCard.tsx` – component used for showing a word and its definition.
+- `__tests__/` – Jest tests and snapshots for components.
+- `__mocks__/` – manual mocks used during tests.
+
+## License
+
+This project is licensed under the ISC license.

--- a/WordCard.tsx
+++ b/WordCard.tsx
@@ -1,11 +1,19 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 
-export function WordCard({ word, definition }: { word: string; definition: string }) {
+export function WordCard({
+  word,
+  definition,
+  reveal,
+}: {
+  word: string;
+  definition: string;
+  reveal?: boolean;
+}) {
   return (
     <View style={styles.card}>
       <Text style={styles.word}>{word}</Text>
-      <Text style={styles.definition}>{definition}</Text>
+      {reveal && <Text style={styles.definition}>{definition}</Text>}
     </View>
   );
 }

--- a/__tests__/WordCard.test.tsx
+++ b/__tests__/WordCard.test.tsx
@@ -4,7 +4,14 @@ import { WordCard } from '../WordCard';
 
 jest.mock('react-native');
 
-test('renders word and definition', () => {
+test('renders word only when not revealed', () => {
   const tree = renderer.create(<WordCard word="test" definition="A test" />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('renders word and definition when revealed', () => {
+  const tree = renderer
+    .create(<WordCard word="test" definition="A test" reveal />)
+    .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/__tests__/__snapshots__/WordCard.test.tsx.snap
+++ b/__tests__/__snapshots__/WordCard.test.tsx.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`renders word and definition 1`] = `null`;
+exports[`renders word and definition when revealed 1`] = `null`;
+
+exports[`renders word only when not revealed 1`] = `null`;


### PR DESCRIPTION
## Summary
- update WordCard to optionally reveal its definition
- show one word at a time and cycle on tap
- document new flashcard flow in README
- update tests and snapshots

## Testing
- `npm install`
- `npm test --silent`
- `npm test --silent -- -u`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684f32578eec83298156e109679f444f